### PR TITLE
refactor: observations auth only for assigned users

### DIFF
--- a/hub-backend/package.json
+++ b/hub-backend/package.json
@@ -76,6 +76,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/hub-backend/src/auth/authorization.service.spec.ts
+++ b/hub-backend/src/auth/authorization.service.spec.ts
@@ -91,4 +91,36 @@ describe('AuthorizationService', () => {
     ).resolves.toBeUndefined();
     expect(findAssignment).not.toHaveBeenCalled();
   });
+
+  it('allows any assigned project member to create observations', async () => {
+    const findAssignment = jest.fn().mockResolvedValue({ id: 4 });
+    const prisma = {
+      projectActorAssignment: { findFirst: findAssignment },
+    };
+    const service = new AuthorizationService(prisma as never);
+
+    await expect(
+      service.assertAssignedProjectMember(user([UserRole.student]), 10),
+    ).resolves.toBeUndefined();
+    expect(findAssignment).toHaveBeenCalledWith({
+      where: { projectId: 10, userId: 7 },
+      select: { id: true },
+    });
+  });
+
+  it('rejects creating observations without a project assignment, including admins', async () => {
+    const findAssignment = jest.fn().mockResolvedValue(null);
+    const prisma = {
+      projectActorAssignment: { findFirst: findAssignment },
+    };
+    const service = new AuthorizationService(prisma as never);
+
+    await expect(
+      service.assertAssignedProjectMember(user([UserRole.admin]), 10),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(findAssignment).toHaveBeenCalledWith({
+      where: { projectId: 10, userId: 7 },
+      select: { id: true },
+    });
+  });
 });

--- a/hub-backend/src/auth/authorization.service.ts
+++ b/hub-backend/src/auth/authorization.service.ts
@@ -25,6 +25,13 @@ export class AuthorizationService {
       return;
     }
 
+    await this.assertAssignedProjectMember(user, projectId);
+  }
+
+  async assertAssignedProjectMember(
+    user: AuthenticatedUser,
+    projectId: number,
+  ): Promise<void> {
     const assignment = await this.prisma.projectActorAssignment.findFirst({
       where: { projectId, userId: user.id },
       select: { id: true },

--- a/hub-backend/src/observations/observations.service.spec.ts
+++ b/hub-backend/src/observations/observations.service.spec.ts
@@ -43,7 +43,7 @@ describe('ObservationsService', () => {
       },
     };
     const authorization = {
-      assertProjectMember: jest.fn().mockResolvedValue(undefined),
+      assertAssignedProjectMember: jest.fn().mockResolvedValue(undefined),
     };
     const service = new ObservationsService(
       prisma as never,
@@ -57,6 +57,10 @@ describe('ObservationsService', () => {
     });
 
     expect(createObservation).toHaveBeenCalledTimes(1);
+    expect(authorization.assertAssignedProjectMember).toHaveBeenCalledWith(
+      user,
+      10,
+    );
     const createCall = createObservation.mock.calls[0];
     expect(createCall).toBeDefined();
     if (!createCall) {
@@ -101,5 +105,28 @@ describe('ObservationsService', () => {
     await expect(
       service.observationsByProject(10, user),
     ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects observation creation for users without a project assignment', async () => {
+    const prisma = {
+      project: { findUnique: jest.fn().mockResolvedValue({ id: 10 }) },
+    };
+    const authorization = {
+      assertAssignedProjectMember: jest
+        .fn()
+        .mockRejectedValue(new ForbiddenException()),
+    };
+    const service = new ObservationsService(
+      prisma as never,
+      authorization as never,
+    );
+
+    await expect(
+      service.createObservation({ projectId: 10, content: 'Note', user }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(authorization.assertAssignedProjectMember).toHaveBeenCalledWith(
+      user,
+      10,
+    );
   });
 });

--- a/hub-backend/src/observations/observations.service.ts
+++ b/hub-backend/src/observations/observations.service.ts
@@ -79,7 +79,10 @@ export class ObservationsService {
     user: AuthenticatedUser;
   }): Promise<ProjectObservationResponse> {
     await this.assertProjectExists(params.projectId);
-    await this.authorization.assertProjectMember(params.user, params.projectId);
+    await this.authorization.assertAssignedProjectMember(
+      params.user,
+      params.projectId,
+    );
 
     const content = params.content?.trim();
 


### PR DESCRIPTION
las observaciones ahora solo son posible para usuarios asignados al proyecto